### PR TITLE
Added notification type for swiftdialog

### DIFF
--- a/fragments/functions.sh
+++ b/fragments/functions.sh
@@ -122,9 +122,10 @@ displayNotification() { # $1: message $2: title
     ;;
     swiftdialog)
       if [ -x "$swiftDialog" ]; then
-        "$swiftDialog" --message "$message" --title "$title" --notification
+        "$swiftDialog" --message "$message" --title "$title" --$swiftDialogNotification
       else
         printlog "ERROR: $swiftDialog not installed for showing notifications.  Falling back to AppleScript"
+        FallBacktoAS=true
       fi
     ;;
     applescript)

--- a/fragments/header.sh
+++ b/fragments/header.sh
@@ -26,7 +26,7 @@ NOTIFICATIONTYPE=jamf
 # Notification Sources
 jamfManagementAction="/Library/Application Support/JAMF/bin/Management Action.app/Contents/MacOS/Management Action"
 swiftDialog="/usr/local/bin/dialog"
-
+swiftDialogNotification=mini
 
 # - appVersionKey: (optional)
 #   How we get version number from app. Default value


### PR DESCRIPTION
Default is still a mini dialog, but changing `swiftDialogNotification` to `notification` will use notifications instead.

Also added `FallBacktoAS=true` to swiftdialog, since it was missing