### PR TITLE
Add OBS iOS Camera plugin

### DIFF
--- a/fragments/labels/obsioscamera.sh
+++ b/fragments/labels/obsioscamera.sh
@@ -1,0 +1,5 @@
+obsioscamera)
+      appTitle="OBS iOS Camera"
+      appProcesses+=("OBS" "OBS Studio")
+      appFiles+=("/Library/Application Support/obs-studio/plugins/obs-ios-camera-source.plugin")
+      ;;


### PR DESCRIPTION
No need for removal of user files (that's handled by the OBS uninstaller)